### PR TITLE
[Feacture #157801243] Add toastr

### DIFF
--- a/app/views/includes/foot.jade
+++ b/app/views/includes/foot.jade
@@ -13,6 +13,8 @@ script(type='text/javascript', src='/lib/bootstrap/dist/js/bootstrap.js')
 script(type='text/javascript', src='https://code.angularjs.org/1.1.5/angular.js')
 script(type='text/javascript', src='https://code.angularjs.org/1.1.5/angular-resource.js')
 script(type='text/javascript', src='https://code.angularjs.org/1.1.5/angular-cookies.js')
+//Toastr
+script(type='text/javascript', src='https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/js/toastr.min.js')
 
 //Angular UI
 script(type='text/javascript', src='/lib/angular-bootstrap/ui-bootstrap-tpls.js')

--- a/app/views/includes/head.jade
+++ b/app/views/includes/head.jade
@@ -27,6 +27,8 @@ head
   link(rel='stylesheet', href='/css/common.css')
   link(rel='stylesheet', href='/css/animate.css')
   link(rel='stylesheet', href='/css/style.css')
+  //Toastr css
+  link(rel="stylesheet", href="https://cdnjs.cloudflare.com/ajax/libs/toastr.js/latest/css/toastr.min.css")
 
 
   //if lt IE 9

--- a/public/js/controllers/index.js
+++ b/public/js/controllers/index.js
@@ -25,12 +25,13 @@ angular.module('mean.system')
         const token = response.data.token;
         if(token){
           localStorage.setItem('token', token);
+          toastr.success('Successfully signed in');
           $location.path('/');
         }
       },
     (response) => {
       const { error } = response.data
-      $scope.hasError = error;
+      toastr.error(error);
     })
     };
 

--- a/public/views/signin.html
+++ b/public/views/signin.html
@@ -41,9 +41,7 @@
 
       <div class="sign-body">
         <div class="more-sign">
-          <div class="sign-error" ng-show="hasError">
-            {{hasError}}
-          </div><br/>
+          
           <form class="signup form-horizontal" ng-submit="login()">
             <div class="control-group">
               <label for="email" class="control-label"></label>


### PR DESCRIPTION
#### What does this PR do?
Add toaster message when successfully signed in

#### Description of Task to be completed?
Add toastr cdn
Display both error and success message with toastr

#### How should this be manually tested?
N/A

#### Any background context you want to provide?
N/A

#### What are the relevant pivotal tracker stories?
story type: feature
story Id: 157801243
story title: Users should receive a JWT on successful login

#### Screenshots (if appropriate)
<img width="1440" alt="loginerror" src="https://user-images.githubusercontent.com/14803275/40946212-3f94e8f6-6854-11e8-9b79-72918cc6ed14.png">
<img width="1440" alt="loginsucces" src="https://user-images.githubusercontent.com/14803275/40946247-5daa5916-6854-11e8-9e4a-5dddcad82906.png">

